### PR TITLE
removed the segmented control that allowed switching to FLAG mode

### DIFF
--- a/screens/PlogScreen.js
+++ b/screens/PlogScreen.js
@@ -16,7 +16,6 @@ import Banner from '../components/Banner';
 import Button from '../components/Button';
 import PlogPhoto from '../components/PlogPhoto';
 import Question from '../components/Question';
-import SegmentedControl from '../components/SegmentedControl';
 import Selectable from '../components/Selectable';
 
 import Options from '../constants/Options';
@@ -29,7 +28,7 @@ import * as actions from '../redux/actions';
 import PlogScreenWeather from './PlogScreenWeather';
 
 class PlogScreen extends React.Component {
-    static modes = ['Log', 'Flag'];
+    static modes = ['Log'];
 
     constructor(props) {
         super(props);
@@ -151,11 +150,6 @@ class PlogScreen extends React.Component {
             <Banner>
                 <PlogScreenWeather />
             </Banner>
-
-            <SegmentedControl selectedIndex={state.selectedMode}
-                              values={PlogScreen.modes}
-                              onChange={this.changeMode}
-            />
 
             <MapView
                 style={[styles.map]}


### PR DESCRIPTION
Deleted the segmented control itself since it doesn't look like it'll be needed anymore, but left most of the structure in place so that it can pretty easily be brought back or more 'modes' can be added. Deleted the Flag mode so that the only entry in the 'modes' array is Log. Again left the code for changeMode() so that it can be easily brought back, theres just nothing that calls it anymore.

This resolves issue 62

Expected:
Plog screen should load the same way, just without the segmented control and Logging a Plog should still work as normal.