### PR TITLE
add example conf to match README

### DIFF
--- a/firebase/config.js.example
+++ b/firebase/config.js.example
@@ -1,0 +1,15 @@
+export default {
+  apiKey: "xxxxxxxxxxxxxxxxx", //new api
+  authDomain: "xxxxxxxxxxxxxxxxx.firebaseapp.com",
+  databaseURL: "https://xxxxxxxxxxxxxxxxx.firebaseio.com",
+  projectId: "xxxxxxxxxxxxxxxxx",
+  storageBucket: "xxxxxxxxxxxxxxxxx.appspot.com",
+  appId: "1:12345678:web:912345678912345678",
+
+
+  auth: {
+    facebook: {
+      appId: "12345678",
+    },
+  },
+};


### PR DESCRIPTION
the README assumes that an example config.js.example file exists, but it doesn