### PR TITLE
Fix intro screen "I'm Ready" button, resolve #80

### DIFF
--- a/components/ScreenSlider.js
+++ b/components/ScreenSlider.js
@@ -38,8 +38,11 @@ class ScreenSlider extends React.Component {
         showingIndex += step;
 
         const len = 4;
-        if (showingIndex >= len)
-            return; //oncomplete
+        if (showingIndex >= len) {
+            this.props.setPreferences({ sawIntro: true });
+            this.props.navigation.goBack();
+            return;
+        }
         if (showingIndex < 0)
             return;
 


### PR DESCRIPTION
Note: "I'm Ready" button now matches "Skip Intro" link, which goes back in nav stack. For new users this directs them to main plogging screen; but if you access the intro screens from the login screen "What is Plogging?" link then both skip intro & final button bring you back to login screen.