### PR TITLE
Fixes spacing at bottom of HistoryScreen

### DIFF
--- a/screens/HistoryScreen.js
+++ b/screens/HistoryScreen.js
@@ -109,10 +109,8 @@ class HistoryScreen extends React.Component {
                         keyExtractor={(_, i) => ''+i}
                         ItemSeparatorComponent={Divider}>
                 </FlatList>
+                <View style={{ height: 25 }} />
             </ScrollView>
-
-            <View style={{ height: 25 }} />
-
         </View>
     );
   }


### PR DESCRIPTION
I think I made a mistake with the location of `<View style={{ height: 25 }} />`, so I've moved it into the ScrollView.