### PR TITLE
Issue 81: Reduce bottom margin on page dots

### DIFF
--- a/components/ScreenSlider.js
+++ b/components/ScreenSlider.js
@@ -144,7 +144,7 @@ const styles = StyleSheet.create({
         height: 16,
         justifyContent: 'center',
         margin: 20,
-        marginBottom: 50,
+        marginBottom: 20,
     },
     slider: {
         flex: 1,


### PR DESCRIPTION
Move the pagination dots down to reveal the continue button, which was being cut off on smaller screens (iPhone 8, Galaxy A6).

Closes #81 

<img width="437" alt="Issue 81 fix" src="https://user-images.githubusercontent.com/5273704/74108315-1547a700-4b47-11ea-8c39-9bdb0d13b14b.png">

