### PR TITLE
Fix close button in invite screen

### DIFF
--- a/screens/InviteModalScreen.js
+++ b/screens/InviteModalScreen.js
@@ -90,10 +90,8 @@ const styles = StyleSheet.create({
   },
   closeModal: {
     position: 'absolute',
-    left: 340,
     right: 0,
     top: 40,
-    bottom: 0,
     borderWidth: 0,
   },
   shareButtons: {


### PR DESCRIPTION
Closes #101 

It worked fine on my device. 

But earlier the styling was:

```
left: 340,	
right: 0,
top: 40,
bottom: 0,
```	

So may be the left value was dragging the close icon out of the screen. So I removed it.

Let me know if something else needed to be done.