### PR TITLE
Speculative local state updates

### DIFF
--- a/firebase/plogs.js
+++ b/firebase/plogs.js
@@ -46,6 +46,7 @@ export const plogStateToDoc = plog => ({
     "Plog" :
     "Flag",
   DateTime: plog.when,
+  TZ: plog.when.getTimezoneOffset(),
   UserID: auth.currentUser.uid,
   Photos: [],
   PlogDuration: plog.timeSpent,
@@ -68,6 +69,7 @@ export const getLocalPlogs = (lat=42.123, long=-71.1234, radius=8000) => {
 
 export const savePlog = async (plog) => {
   const doc = Plogs.doc();
+  console.log(plog.when);
   await doc.set(plogStateToDoc(plog));
 
   if (!plog.plogPhotos || !plog.plogPhotos.length)

--- a/firebase/plogs.js
+++ b/firebase/plogs.js
@@ -36,6 +36,24 @@ export const plogDocToState = (plog) => {
   };
 };
 
+export const plogStateToDoc = plog => ({
+  TrashTypes: plog.trashTypes,
+  ActivityType: plog.activityType,
+  coordinates: new GeoPoint(plog.location.lat, plog.location.lng),
+  GeoLabel: plog.location ? plog.location.name : "mid atlantic",
+  HelperType: plog.groupType,
+  PlogType: plog.pickedUp ?
+    "Plog" :
+    "Flag",
+  DateTime: plog.when,
+  UserID: auth.currentUser.uid,
+  Photos: [],
+  PlogDuration: plog.timeSpent,
+  Public: !!plog.public,
+  UserProfilePicture: plog.userProfilePicture || null,
+  UserDisplayName: plog.userDisplayName,
+});
+
 export function queryUserPlogs(userId) {
   return Plogs.where('UserID', '==', userId);
 }
@@ -50,23 +68,7 @@ export const getLocalPlogs = (lat=42.123, long=-71.1234, radius=8000) => {
 
 export const savePlog = async (plog) => {
   const doc = Plogs.doc();
-  await doc.set({
-    TrashTypes: plog.trashTypes,
-    ActivityType: plog.activityType,
-    coordinates: new GeoPoint(plog.location.lat, plog.location.lng),
-    GeoLabel: plog.location ? plog.location.name : "mid atlantic",
-    HelperType: plog.groupType,
-    PlogType: plog.pickedUp ?
-      "Plog" :
-      "Flag",
-    DateTime: plog.when,
-    UserID: auth.currentUser.uid,
-    Photos: [],
-    PlogDuration: plog.timeSpent,
-    Public: !!plog.public,
-    UserProfilePicture: plog.userProfilePicture || null,
-    UserDisplayName: plog.userDisplayName,
-  });
+  await doc.set(plogStateToDoc(plog));
 
   if (!plog.plogPhotos || !plog.plogPhotos.length)
       return;

--- a/firebase/project/functions/package.json
+++ b/firebase/project/functions/package.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "8"
+    "node": "10"
   },
   "dependencies": {
     "firebase-admin": "^8.6.0",

--- a/redux/actionTypes.js
+++ b/redux/actionTypes.js
@@ -2,6 +2,9 @@ export const LOG_PLOG = 'LOG_PLOG';
 export const LOG_PLOG_ERROR = 'LOG_PLOG_ERROR';
 export const PLOG_LOGGED = 'PLOG_LOGGED';
 
+export const LIKE_PLOG = 'LIKE_PLOG';
+export const LIKE_PLOG_ERROR = 'LIKE_PLOG_ERROR';
+
 export const PLOGS_UPDATED = 'PLOGS_UPDATED';
 export const PLOG_UPDATED = 'PLOG_UPDATED';
 export const LOCAL_PLOGS_UPDATED = 'LOCAL_PLOGS_UPDATED';

--- a/redux/actions.js
+++ b/redux/actions.js
@@ -50,8 +50,19 @@ export const plogUpdated = plog => ({
 });
 
 export const likePlog = (plogID, like) => (
-  async _ => {
-    functions.likePlog(plogID, like);
+  async dispatch => {
+    try {
+      dispatch({
+        type: types.LIKE_PLOG,
+        payload: { plogID, like }
+      });
+      await functions.likePlog(plogID, like);
+    } catch(error) {
+      dispatch({
+        type: types.LIKE_PLOG_ERROR,
+        payload: { plogID, like, error }
+      });
+    }
   }
 );
 

--- a/redux/reducers/plogs.js
+++ b/redux/reducers/plogs.js
@@ -7,7 +7,12 @@ import {
   LOCAL_PLOGS_UPDATED,
   PLOG_LOGGED,
   LOG_PLOG_ERROR,
+  LIKE_PLOG,
+  LIKE_PLOG_ERROR,
 } from "../actionTypes";
+
+import { specUpdate, revert } from '../../util/redux';
+
 
 /** @type {import('immutable').Map} */
 const initialState = fromJS({
@@ -18,9 +23,11 @@ const initialState = fromJS({
 });
 
 const log = (state = initialState, action) => {
+  const {type, payload} = action;
+
     switch (action.type) {
     case LOG_PLOG:
-      return state.merge({ submitting: action.payload.plog, logError: null });
+      return state.merge({ submitting: payload.plog, logError: null });
 
     case PLOG_LOGGED:
       return state.set("submitting", null);
@@ -29,7 +36,7 @@ const log = (state = initialState, action) => {
       return state.merge({ submitting: null, logError: action.error });
 
     case SET_CURRENT_USER: {
-        if (!action.payload.user)
+        if (!payload.user)
             return state.set(
                 "history",
                 fromJS([]));
@@ -39,14 +46,20 @@ const log = (state = initialState, action) => {
 
     case PLOGS_UPDATED:
     case LOCAL_PLOGS_UPDATED: {
-      const {plogs = []} = action.payload;
+      const {plogs = []} = payload;
       const newState = state.set(
         action.type === PLOGS_UPDATED ? 'history' : 'localPlogs',
         Seq(plogs).map(p => p.id)
       )
-        .mergeIn(['plogData'], Seq(action.payload.plogs).map(plog => ([plog.id, fromJS(plog)])));
+        .mergeIn(['plogData'], Seq(payload.plogs).map(plog => ([plog.id, fromJS(plog)])));
       return newState;
     }
+
+    case LIKE_PLOG:
+      return specUpdate(state, ['plogData', payload.plogID, 'likeCount'], 0, count => (payload.like ? count+1 : count-1));
+
+    case LIKE_PLOG_ERROR:
+      return revert(state, ['plogData', payload.plogID, 'likeCount']);
 
     default:
       return state;

--- a/redux/reducers/plogs.js
+++ b/redux/reducers/plogs.js
@@ -1,4 +1,4 @@
-import { fromJS } from "immutable";
+import { fromJS, Seq } from "immutable";
 
 import {
     LOG_PLOG,
@@ -9,10 +9,12 @@ import {
   LOG_PLOG_ERROR,
 } from "../actionTypes";
 
+/** @type {import('immutable').Map} */
 const initialState = fromJS({
-    // Look up a plog by ID
-    history: [],
-    localPlogs: [],
+  // Look up a plog by ID
+  plogData: {},
+  history: [],
+  localPlogs: [],
 });
 
 const log = (state = initialState, action) => {
@@ -35,22 +37,19 @@ const log = (state = initialState, action) => {
         return state;
     }
 
-    case PLOGS_UPDATED: {
-        return state.set(
-            "history",
-            fromJS(action.payload.plogs)
-        );
+    case PLOGS_UPDATED:
+    case LOCAL_PLOGS_UPDATED: {
+      const {plogs = []} = action.payload;
+      const newState = state.set(
+        action.type === PLOGS_UPDATED ? 'history' : 'localPlogs',
+        Seq(plogs).map(p => p.id)
+      )
+        .mergeIn(['plogData'], Seq(action.payload.plogs).map(plog => ([plog.id, fromJS(plog)])));
+      return newState;
     }
 
-    case LOCAL_PLOGS_UPDATED: {
-        return state.set(
-            "localPlogs",
-            fromJS(action.payload.plogs)
-        );
-    }
-    default: {
-        return state;
-    }
+    default:
+      return state;
     }
 };
 

--- a/redux/reducers/users.js
+++ b/redux/reducers/users.js
@@ -2,8 +2,13 @@ import { Map, fromJS } from "immutable";
 import * as types from "../actionTypes";
 
 import { specUpdate, revert } from '../../util/redux';
+import { updateAchievements, updateStats } from '../../firebase/project/functions/shared';
+import { plogStateToDoc } from '../../firebase/plogs';
 
 
+/**
+ * @param {Map} state
+ */
 export default usersReducer = (state = Map(), {type, payload}) => {
   switch (type) {
     case types.SET_CURRENT_USER: {
@@ -27,6 +32,12 @@ export default usersReducer = (state = Map(), {type, payload}) => {
 
   case types.LIKE_PLOG_ERROR:
     return revert(state, ['current', 'data', 'likedPlogs', payload.plogID]);
+
+  case types.PLOG_LOGGED: {
+    const plogData = plogStateToDoc(payload.plog);
+    return state.updateIn(['current', 'data', 'stats'], Map(), stats => fromJS(updateStats(stats.toJS(), plogData)) )
+      .updateIn(['current', 'data', 'achievements'], Map(), data => fromJS(updateAchievements(data.toJS(), plogData)));
+  }
 
     case types.LOCATION_CHANGED: {
         return state.set('location', payload.location);

--- a/redux/reducers/users.js
+++ b/redux/reducers/users.js
@@ -1,6 +1,8 @@
 import { Map, fromJS } from "immutable";
 import * as types from "../actionTypes";
 
+import { specUpdate, revert } from '../../util/redux';
+
 
 export default usersReducer = (state = Map(), {type, payload}) => {
   switch (type) {
@@ -18,6 +20,13 @@ export default usersReducer = (state = Map(), {type, payload}) => {
                            ['users', payload.UserID, 'data'],
                           fromJS(payload.data));
     }
+
+  case types.LIKE_PLOG:
+    return specUpdate(state, ['current', 'data', 'likedPlogs', payload.plogID],
+                      payload.like);
+
+  case types.LIKE_PLOG_ERROR:
+    return revert(state, ['current', 'data', 'likedPlogs', payload.plogID]);
 
     case types.LOCATION_CHANGED: {
         return state.set('location', payload.location);

--- a/screens/HistoryScreen.js
+++ b/screens/HistoryScreen.js
@@ -53,9 +53,13 @@ class HistoryScreen extends React.Component {
   }
 }
 
-export default connect(store => ({
-    history: store.log.get('history').sort((a, b) => (b.get('when') - a.get('when'))),
-    currentUser: store.users.get('current').toJS(),
-}), dispatch => ({
+export default connect(({log, users}) => {
+  const plogs = log.get('plogData');
+
+  return {
+    history: log.get('history').map(id => plogs.get(id)).sort((a, b) => (b.get('when') - a.get('when'))),
+    currentUser: users.get('current').toJS(),
+  };
+}, dispatch => ({
   likePlog: (...args) => dispatch(actions.likePlog(...args)),
 }))(HistoryScreen);

--- a/screens/LocalScreen.js
+++ b/screens/LocalScreen.js
@@ -37,9 +37,13 @@ class LocalScreen extends React.Component {
     }
 }
 
-export default connect(store => ({
-    history: store.log.get('localPlogs').sort((a, b) => (b.get('when') - a.get('when'))),
-    currentUser: store.users.get('current').toJS(),
-}), dispatch => ({
+export default connect(({log, users}) => {
+  const plogs = log.get('plogData');
+
+  return {
+    history: log.get('localPlogs').map(id => plogs.get(id)).sort((a, b) => (b.get('when') - a.get('when'))),
+    currentUser: users.get('current').toJS(),
+  };
+}, dispatch => ({
   likePlog: (...args) => dispatch(actions.likePlog(...args)),
 }))(LocalScreen);

--- a/util/redux.js
+++ b/util/redux.js
@@ -1,0 +1,39 @@
+import * as Immutable from "immutable";
+
+
+const $R = Symbol();
+
+/**
+ * Make a speculative change to state
+ *
+ * @template K, V
+ * @param {Immutable.Map<K, V>} state
+ * @param {Iterable<K>} keypath
+ * @returns Immutable.Map<K, V>
+ */
+export function specUpdate(state, keypath, ...args) {
+  const optArgs = args.slice(0, -1);
+  let updater = args[args.length-1];
+  if (typeof updater !== 'function') {
+    const val = updater;
+    updater = (_ => val);
+  }
+  return state
+    .setIn([$R, ...keypath], state.getIn(keypath))
+    .updateIn(keypath, ...optArgs, updater);
+};
+
+/** @type {typeof specUpdate} */
+export function revert(state, keypath) {
+  const revertPath = [$R, ...keypath];
+  const revertValue = state.getIn(revertPath);
+
+  return (
+    revertValue === undefined ?
+      state.removeIn(keypath) :
+      state.setIn(keypath, revertValue)
+  ).removeIn(revertPath);
+}
+
+/** @type {typeof specUpdate} */
+export const commit = (state, keypath) => state.removeIn([$R, ...keypath]);


### PR DESCRIPTION
This PR makes a few changes designed to improve the responsiveness of the UI when performing operations that depend on cloud operations. 
78ae67b normalizes the storage of plog data in local state, making it simpler to perform updates on individual plogs and reducing the duplicate plogs in memory.
9cd348c adds speculative local updates to the plog like count and status when a user *likes* a plog, rolling back if there's an error in the cloud function. 
98abdf1 moves code related to user stats and achievements to a module shared between the front- and back-end, enabling local updates to that data when a user plogs. The commit also fixes some issues with achievements calculation.

To test, you'll need to deploy the functions to firebase. (`firebase deploy --only functions`)