### PR TITLE
adds temp to PlogScreenWeather banner (issue 147)

### DIFF
--- a/icons.js
+++ b/icons.js
@@ -25,4 +25,21 @@ import Profile from './assets/svg/profile.svg';
 
 import Camera from './assets/svg/photo-camera.svg';
 
-export default {Walk, Teacher, Dog, Couple, Multiple, Family, Team, Group, Running, Bike, Canoe, Waterpolo, Swimmer, Horseriding, History, Pointer, Track, User, Backpacker, Camera, Profile};
+import ClearSky from './assets/images/weather_icons_pngs/01dSunFlaticon.png';
+import FewClouds from './assets/images/weather_icons_pngs/02dFewCloudsFlaticon.png';
+import ScatteredCloudy from './assets/images/weather_icons_pngs/03dScatteredCloudyFlaticon.png';
+import BrokenClouds from './assets/images/weather_icons_pngs/04dBrokenCloudsFlaticon.png';
+import ShowerRain from './assets/images/weather_icons_pngs/09dShowerRainFlaticon.png';
+import Rain from './assets/images/weather_icons_pngs/10dRainFlaticon.png';
+import Thunderstorm from './assets/images/weather_icons_pngs/11dStormFlaticon.png';
+import Snow from './assets/images/weather_icons_pngs/13dSnowFlaticon.png';
+import Mist from './assets/images/weather_icons_pngs/50dMistFlaticon.png';
+
+
+export default {
+    Walk, Teacher, Dog, Couple, Multiple, Family, Team, Group, 
+    Running, Bike, Canoe, Waterpolo, Swimmer, Horseriding, 
+    History, Pointer, Track, User, Backpacker, Camera, Profile, 
+    ClearSky, FewClouds, ScatteredCloudy, BrokenClouds,
+    ShowerRain, Rain, Thunderstorm, Snow, Mist
+};

--- a/screens/PlogScreenWeather.js
+++ b/screens/PlogScreenWeather.js
@@ -5,13 +5,13 @@ import * as Location from 'expo-location';
 
 import config from '../config';
 
-
 class PlogScreenWeather extends Component {
   constructor() {
     super();
     this.state = {
       error: null,
-      weatherDetails: null
+      weatherDetails: null,
+      temperature: null
     };
   }
   render() {
@@ -22,6 +22,10 @@ class PlogScreenWeather extends Component {
       return this.renderLoading()
     } else {
       const plogMessage = { message: "Sample welcome message" };
+      const tempC = this.state.temperature/*weatherDetails.main.temp*/;
+      const tempF = (tempC * 9 / 5) + 32;
+      const temps = " " + tempF.toFixed(0) + "\xB0" + "F / " + tempC.toFixed(0) + "\xB0" + "C";
+//      let weatherIcon;
       const tempMin = this.state.weatherDetails.main.temp_min;
       const tempMax = this.state.weatherDetails.main.temp_max;
       const atmospheric = this.state.weatherDetails.weather.id;
@@ -93,7 +97,7 @@ class PlogScreenWeather extends Component {
       console.log(plogMessage.message);
       return (
         <Text>
-          {plogMessage.message}
+          {plogMessage.message} - {/*{weatherIcon}*/} {temps}
         </Text>
       );
     }
@@ -111,8 +115,7 @@ class PlogScreenWeather extends Component {
           {/* console.warn("Missing API key"); */}
         } else {
         fetch("http://api.openweathermap.org/data/2.5/weather" 
-          + toGetWeather 
-            + "&units=metric&APPID=" + apiKey)
+          + toGetWeather + "&units=metric&APPID=" + apiKey)
 // Contact the dev team for the api key, and only use it in your local work for the time being if you need to.
 // This is to avoid losing control of the api key and it being overused or misused.
             .then(response => {
@@ -124,7 +127,8 @@ class PlogScreenWeather extends Component {
               response.json()
               .then(data => {
                 this.setState({
-                  weatherDetails: data
+                  weatherDetails: data,
+                  temperature: data.main.temp
                 })
               })
             })


### PR DESCRIPTION
Adds temperature in Fahrenheit and Celsius to the PlogScreenWeather banner on the Plog Screen.

This PR does not have the weather icons yet.  So this PR does not fully address issue 147.

I've included a variable `weatherIcon` (commented out) as a placeholder.

I've selected pngs and svgs from Flaticon.  I'll submit them once I've figured out the display logic for them.