### PR TITLE
Fix Issue 131: Clear "email already is use" error 

### DIFF
--- a/components/DismissButton.jsx
+++ b/components/DismissButton.jsx
@@ -5,13 +5,23 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
+import { connect } from 'react-redux';
+import * as actions from '../redux/actions';
 
 
-const DismissButton = ({color = 'black', title, style, ...props}) => {
+const DismissButton = ({color = 'black', title, style, shouldClearError = false, ...props}) => {
     const navigation = useNavigation();
 
+    const onPressOut = () => {
+        if (shouldClearError) {
+            props.clearSignupError()
+        }
+
+        navigation.pop()
+    }
+
     return (
-      <TouchableOpacity onPress={() => navigation.pop()}
+      <TouchableOpacity onPress={onPressOut}
                         accessibilityLabel={title || 'close'}
                         accessibilityRole="button"
                         {...props}>
@@ -28,5 +38,11 @@ const styles = StyleSheet.create({
     }
 });
 
+const ReduxDismissButton = connect(
+    null,
+    dispatch => ({
+        clearSignupError: () => dispatch(actions.signupError()),
+    })
+)(DismissButton);
 
-export default DismissButton;
+export default ReduxDismissButton;

--- a/redux/actions.js
+++ b/redux/actions.js
@@ -21,7 +21,7 @@ const loginError = (err) => ({
     }
 });
 
-const signupError = (error) => ({
+export const signupError = (error) => ({
     type: types.SIGNUP_ERROR,
     payload: { error }
 });

--- a/screens/Signup.js
+++ b/screens/Signup.js
@@ -48,7 +48,14 @@ class SignupScreen extends React.Component {
     render() {
         const {params} = this.state;
         const {error, navigation} = this.props;
-        const setParam = param => (text => this.setState(({params}) => ({params: { ...params, [param]: text }})));
+        
+        const setParam = param => (text => {
+            this.setState(({params}) => ({params: { ...params, [param]: text }}))
+
+            // Clear error message if user enters new text
+            this.props.clearSignupError()
+        });
+        
         const currentUser = this.props.currentUser && this.props.currentUser.toJS();
         const providers = currentUser && currentUser.providerData.reduce(
             (map, provider) => {
@@ -58,7 +65,7 @@ class SignupScreen extends React.Component {
 
         return (
             <View style={[$S.container, $S.form]}>
-              <DismissButton color="black" />
+              <DismissButton color="black" shouldClearError={true}/>
               {error && <Error error={error}/>}
               {
               !providers['password'] ?
@@ -155,6 +162,7 @@ const ReduxSignupScreen = connect(
     dispatch => ({
         linkToEmail: (...args) => dispatch(actions.linkToEmail(...args)),
         linkToGoogle: (...args) => dispatch(actions.linkToGoogle(...args)),
+        clearSignupError: (...args) => dispatch(actions.signupError()),
     })
 )(SignupScreen);
 


### PR DESCRIPTION
fix(signup error): Clear signup error if user re-enters email or closes modal

Dispatch an empty SIGNUP_ERROR action if the user changes the TextInput values on the Signup form.

Adds a `shouldClearError` prop to the DismissButton, with a default value of false.  If true, the DismissButton will dispatch an empty SIGNUP_ERROR action when it is pressed.

Closes #131