### PR TITLE
Removes scrollbar below Achievements (issue 60 tweak)

### DIFF
--- a/components/AchievementSwipe.js
+++ b/components/AchievementSwipe.js
@@ -60,6 +60,7 @@ class AchievementSwipe extends React.PureComponent {
                 keyExtractor={item => item.key}
                 pagingEnabled={true}
                 horizontal={true}
+                showsHorizontalScrollIndicator={false}
             >
             </FlatList>
         );


### PR DESCRIPTION
For the Outstanding Tweak for issue 60 (Implement 'filmstrip' UI).

I don't have any Achievements associated with my plogging, so I can't actually see if this works.  If others would take a look, I'd greatly appreciate it.