### PR TITLE
Update privacy and terms and conditions

### DIFF
--- a/screens/MoreScreen.js
+++ b/screens/MoreScreen.js
@@ -50,8 +50,8 @@ export class MoreScreen extends React.Component {
     {label: 'Achievements', route: 'Achievements'},
     {label: 'Contact Us', route: 'Contact Us'},
     {label: 'Plogging Supplies', route: 'Plogging Supplies'},
-    {label: 'Privacy', route: 'Privacy'},
-    {label: 'Terms', route: 'Terms'},
+    {label: 'Privacy & Security', route: 'Privacy & Security'},
+    {label: 'Terms & Conditions', route: 'Terms & Conditions'},
   ];
 
   render() {
@@ -93,8 +93,8 @@ export default ({navigation, route}) => {
           <Stack.Screen name="About" component={ AboutScreen }/>
           <Stack.Screen name="Achievements" component={ AchievementScreen }/>
           <Stack.Screen name="Contact Us" component={ ContactScreen }/>
-          <Stack.Screen name="Privacy" component={ PrivacyScreen }/>
-          <Stack.Screen name="Terms" component={ TermsScreen }/>
+          <Stack.Screen name="Privacy &amp; Security" component={ PrivacyScreen }/>
+          <Stack.Screen name="Terms &amp; Conditions" component={ TermsScreen }/>
           <Stack.Screen name="Plogging Supplies" component={ PloggingSuppliesScreen }/>
         </Stack.Navigator>
     );

--- a/screens/PrivacyScreen.jsx
+++ b/screens/PrivacyScreen.jsx
@@ -9,7 +9,7 @@ import { A, OpenURLButton } from '../components/Link';
 import $S from '../styles';
 
 const firebasePrivacyURL = "https://firebase.google.com/support/privacy";
-const plogalongPrivacyURL = ""; // TODO: Iubenda
+const plogalongPrivacyURL = "https://app.termly.io/document/privacy-policy/34e2a625-a793-44ce-b92c-a5872d420597";
 const mainMessage =
   "You must share your location with the app to log your plogs, but you can choose to keep your plogs private. Your plogging data is stored securely in ";
 const privacyDetails =
@@ -32,7 +32,7 @@ export default class PrivacyScreen extends React.Component {
     return (
       <ScrollView style={$S.container}>
         <View style={$S.bodyContainer}>
-          <Text style={$S.body} selectable={true}>{mainMessage}<A href={firebasePrivacyURL}>Google Firebase</A></Text>
+          <Text style={$S.body} selectable={true}>{mainMessage}<A href={firebasePrivacyURL}>Google Firebase</A>.</Text>
           {privacyDetails.split('\n').map((text, i) => (
             <LI key={i}>{text.trim()}</LI>
           ))}

--- a/screens/TermsScreen.js
+++ b/screens/TermsScreen.js
@@ -5,15 +5,16 @@ import {
   View,
 } from "react-native";
 
-import { OpenURLButton } from '../components/Link';
+import { A, OpenURLButton } from '../components/Link';
 
 import $S from '../styles';
 
-const websiteURL = "https://www.plogalong.com/";
+const disclaimerURL = "https://app.termly.io/document/disclaimer/e6911739-21db-4678-84a0-68ffc4b597b1";
 const mainMessage =
-  "TODO";
-const createdBy =
-  "";
+  "Slipper Studios, LLC, with partnership with Code for Boston, built the Plogalong app as an Open Source app. This Service is provided by Slipper Studios, LLC at no cost, and is intended for use as is.";
+const termsURL = "https://app.termly.io/document/terms-of-use-for-ios-app/a3df3866-e2e8-4a51-8ac1-a4b41efe140b"
+const guidelines =
+  "This app is intended to be used outdoors. You are responsible for your safety while using the app. Slipper Studios, LLC, does not accept liability for any risks, hazards, injuries, or other harm that may come to you while plogging.";
 
 export default class TermsScreen extends React.Component {
   render() {
@@ -21,10 +22,22 @@ export default class TermsScreen extends React.Component {
       <ScrollView style={$S.container}>
         <View style={$S.bodyContainer}>
           <Text style={$S.body}>{mainMessage}</Text>
-          <Text style={$S.body}>{createdBy}</Text>
         </View>
-
-        <OpenURLButton url={websiteURL}>Visit plogalong.com</OpenURLButton>
+        <OpenURLButton url={termsURL}>View Terms &amp; Conditions</OpenURLButton>
+        <View style={$S.bodyContainer}>
+          <Text style={$S.h1}>Safe Plogging Guidelines</Text>
+          <Text style={$S.body}>{guidelines}</Text>
+          <View style={{ alignItems: 'flex-start', marginBottom: 15, }}>
+            <Text style={{fontSize: 18, marginBottom: 15}}>{`\u2022`}    Plog at your own risk</Text>
+            <Text style={{fontSize: 18, marginBottom: 15}}>{`\u2022`}    Use caution when plogging, or encouraging others to plog</Text>
+            <Text style={{fontSize: 18, marginBottom: 15}}>{`\u2022`}    Use protective equipment, including <A href="https://amzn.to/2WrVbEk">masks</A>, <A href="https://amzn.to/35Sfk9D">gloves</A>, and <A href="https://amzn.to/3bvmW2S">trash grabbers</A>.</Text>
+            <Text style={{fontSize: 18, marginBottom: 15}}>{`\u2022`}    Report sharp or dangerous objects to your town or city</Text>
+            <Text style={{fontSize: 18,}}>{`\u2022`}    Supervise children while plogging</Text>
+          </View>
+        </View>
+        <View style={{marginBottom: 30}}>
+          <OpenURLButton url={disclaimerURL}>View Disclaimer</OpenURLButton>
+        </View>
       </ScrollView>
     );
   }


### PR DESCRIPTION
This updates the privacy (gh-207) and terms and conditions (gh-208). Here are a couple of screenshots on iphone11: 
<img width="328" alt="Screen Shot 2020-11-13 at 12 29 48 PM" src="https://user-images.githubusercontent.com/16979745/99103945-51180d00-25ae-11eb-8831-76c9745ab176.png">
<img width="328" alt="Screen Shot 2020-11-13 at 12 29 57 PM" src="https://user-images.githubusercontent.com/16979745/99103950-52e1d080-25ae-11eb-9fb3-44a0092e9ab5.png">
<img width="328" alt="Screen Shot 2020-11-13 at 12 30 07 PM" src="https://user-images.githubusercontent.com/16979745/99103955-5412fd80-25ae-11eb-91d4-a0f566d659c5.png">

As I was pushing up the code, I noticed that @zachjohnston assigned himself #208. Sorry, Zach, if I strayed into work you were hoping to do! The two issues were so similar, I just batched them.


