### PR TITLE
Add support for local notifications

### DIFF
--- a/App.js
+++ b/App.js
@@ -18,6 +18,8 @@ import makeStore from "./redux/store";
 import AppNavigator from './navigation/AppNavigator';
 import FlashMessage from './FlashMessage';
 import { PromptRenderer } from './Prompt';
+import * as Notifications from "expo-notifications";
+import * as Permissions from "expo-permissions";
 
 
 export default class App extends React.Component {
@@ -41,6 +43,19 @@ export default class App extends React.Component {
     Keyboard.dismiss();
     return false;
   }
+
+  componentDidMount() {
+    this.askPermissions();
+  }
+
+  async askPermissions() {
+    const { status: existingStatus } = await Permissions.getAsync(Permissions.NOTIFICATIONS);
+    let finalStatus = existingStatus;
+    if (existingStatus !== "granted") {
+      const { status } = await Permissions.askAsync(Permissions.NOTIFICATIONS);
+      finalStatus = status;
+    }
+  };
 
   render() {
     const {preferences} = this.state;

--- a/App.js
+++ b/App.js
@@ -44,17 +44,6 @@ export default class App extends React.Component {
     return false;
   }
 
-  componentDidMount() {
-    this.requestNotificationPermissions();
-  }
-
-  async requestNotificationPermissions() {
-    const { status: existingStatus } = await Permissions.getAsync(Permissions.NOTIFICATIONS);
-    if (existingStatus !== "granted") {
-      await Permissions.askAsync(Permissions.NOTIFICATIONS);
-    }
-  };
-
   render() {
     const {preferences} = this.state;
 

--- a/App.js
+++ b/App.js
@@ -45,15 +45,13 @@ export default class App extends React.Component {
   }
 
   componentDidMount() {
-    this.askPermissions();
+    this.requestNotificationPermissions();
   }
 
-  async askPermissions() {
+  async requestNotificationPermissions() {
     const { status: existingStatus } = await Permissions.getAsync(Permissions.NOTIFICATIONS);
-    let finalStatus = existingStatus;
     if (existingStatus !== "granted") {
-      const { status } = await Permissions.askAsync(Permissions.NOTIFICATIONS);
-      finalStatus = status;
+      await Permissions.askAsync(Permissions.NOTIFICATIONS);
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,9 @@
     "react-redux": "^7.2.0",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
-    "yup": "^0.28.3"
+    "yup": "^0.28.3",
+    "expo-notifications": "~0.7.2",
+    "expo-permissions": "~9.3.0"
   },
   "devDependencies": {
     "babel-preset-expo": "^8.3.0",

--- a/screens/PlogScreen.js
+++ b/screens/PlogScreen.js
@@ -41,6 +41,7 @@ import PlogScreenWeather from './PlogScreenWeather';
 import { useSerializableState } from '../util/native';
 import LoadingIndicator from '../components/Loading';
 
+import * as Permissions from 'expo-permissions';
 
 class PlogScreen extends React.Component {
   static modes = ['Log'];
@@ -272,6 +273,12 @@ class PlogScreen extends React.Component {
     this.props.timer.reset();
   }
 
+  async requestNotificationPermissions(onRequestCompletion) {
+      Permissions.askAsync(Permissions.NOTIFICATIONS).then(() => {
+        onRequestCompletion()
+      })
+  };
+
   formatTimer = () => {
     const difference = this.props.timer.total/1000;
     let hours   = Math.floor(difference / 3600);
@@ -434,7 +441,14 @@ class PlogScreen extends React.Component {
           <View style={styles.timerButtonContainer} pointerEvents="box-none" >
             <Button
               title={this.props.timer.started ? 'STOP TIMER' : 'START TIMER'}
-              onPress={this.toggleTimer}
+              onPress={async () => { 
+                const { status: existingStatus } = await Permissions.getAsync(Permissions.NOTIFICATIONS);
+                if (existingStatus !== "granted") {
+                  this.requestNotificationPermissions(() => this.props.timer.toggle());
+                } else {
+                  this.props.timer.toggle();
+                }
+              }}
               style={styles.timerButton}
               selected={!!this.props.timer.started}
             />

--- a/util/timer.js
+++ b/util/timer.js
@@ -6,6 +6,8 @@ import CachingImage from '../components/Image';
 
 const ONE_HOUR =  60 * 60;
 
+let scheduledNotificationId;
+
 const initialTimerState = {
   started: null,
   time: 0,
@@ -15,17 +17,18 @@ const initialTimerState = {
 const scheduleLocalNotification = async (time) => {
     // Only schedule local notification if time spent plogging when starting timer is less than 1 hour.
     const timeUntilOneHour = ONE_HOUR - time;
-    await Notifications.scheduleNotificationAsync({
+    scheduledNotificationId = await Notifications.scheduleNotificationAsync({
       content: {
-        title: "Great stuff!",
+        title: "Hey Plogger!",
         body: "You've been plogging for an hour. Don't forget to log your journey!",
       },
       trigger: { seconds: timeUntilOneHour },
     });
 };
 
-const cancelScheduledNotifications = async () => {
-  await Notifications.cancelAllScheduledNotificationsAsync();
+const cancelScheduledNotification = async (notificationId) => {
+  await Notifications.cancelScheduledNotificationAsync(notificationId);
+  scheduledNotificationId = null; 
 };
 
 export const useTimer = (init=initialTimerState, store='com.plogalong.plogalong.plogTimer') => {
@@ -69,7 +72,7 @@ export const useTimer = (init=initialTimerState, store='com.plogalong.plogalong.
 
           const time = state.time + (Date.now() - state.started);
           clearTimeout(intervalRef.current);
-          cancelScheduledNotifications();
+          cancelScheduledNotification(scheduledNotificationId);
           newState = {
             ...state,
             started: null,


### PR DESCRIPTION
This PR adds support for local notifications per [this issue.](https://github.com/codeforboston/plogalong/issues/293)

- Add `expo-notifications` & `expo-permissions` dependencies.
- Schedules a local notification to fire after an hour has been spent plogging.

When the user starts blogging, we check if the timer on the time is less than an hour, and if so, schedule a notification to fire when the user has been blogging for a cumulative total of 1 hour. We schedule notifications on start and clear any scheduled on stop.

Tested and working on iOS & Android.

To test, you can either wait an hour with app in the background & the timer running or adjust ONE_HOUR constant to the number seconds you'd like the notification to fire after.

Happy to adjust the notification payload or any other details.
