### PR TITLE
Replace TouchableOpacity with View

### DIFF
--- a/components/ScreenSlider.js
+++ b/components/ScreenSlider.js
@@ -86,9 +86,9 @@ class ScreenSlider extends React.Component {
         return (
             <View style={styles.paginationDots}>
               {pages.map((_, i) => (
-                  <TouchableOpacity key={i}
-                                    style={[styles.dot,
-                                           i === showingIndex && styles.activeDot]}/>
+                  <View key={i}
+                        style={[styles.dot,
+                                i === showingIndex && styles.activeDot]}/>
               ))}
             </View>
         );


### PR DESCRIPTION
This TouchableOpacity does not appear to be doing anything, and we think it may be causing accessibility warnings in the Android pre-launch tests, since it does not have accessibility attributes.  It seems safe to make it a View instead.